### PR TITLE
Fix: Skip emphasis parsing when inside link

### DIFF
--- a/smd.js
+++ b/smd.js
@@ -1298,6 +1298,7 @@ export function parser_write(p, chunk) {
         case '_':
         case '*': {
             if (p.token === IMAGE ||
+                p.token === LINK ||
                 p.token === EQUATION_BLOCK ||
                 p.token === EQUATION_INLINE ||
                 p.token === STRONG_AST)

--- a/smd_test.js
+++ b/smd_test.js
@@ -753,6 +753,18 @@ test_single_write("Link",
     }]
 )
 
+test_single_write("Link with Underline",
+    "[title_with_underline](url)",
+    [{
+        type: smd.Token.Paragraph,
+        children: [{
+            type: smd.Token.Link,
+            attrs: { [smd.Attr.Href]: "url" },
+            children: ["title_with_underline"],
+        }]
+    }]
+)
+
 test_single_write("Link with code",
     "[`title`](url)",
     [{


### PR DESCRIPTION
Considering we have a link with an underscore like this:

`[read_md.md](https://github.com/thetarnav/streaming-markdown)`

We might mistakenly parse the `_` in the link as an underscore mark, resulting in incorrect insertion of `<em>` tags in the link.

We would end up with a link formatted like this:

`readmd.md](https://github.com/thetarnav/streaming-markdown)`

Its DOM structure would resemble:

`<a>read<em>md.md](https://github.com/thetarnav/streaming-markdown)）</em></a>`

<img width="812" height="68" alt="image" src="https://github.com/user-attachments/assets/732a20ce-3362-405e-90e7-6ab3f5243124" />


This Pull Request fixes the issue by skipping underscore parsing when encountering _ while the current token is a link.
